### PR TITLE
Add `BillValidationError` to JourneySquad project. 

### DIFF
--- a/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
+++ b/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		9B0383B92A04D7F4005E333D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0383B82A04D7F4005E333D /* ContentView.swift */; };
 		9B0383BB2A04D7F6005E333D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BA2A04D7F6005E333D /* Assets.xcassets */; };
 		9B0383BE2A04D7F6005E333D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */; };
+		9BB770FF2A0E1E8100C14987 /* BillValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB770FE2A0E1E8100C14987 /* BillValidationError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,6 +20,7 @@
 		9B0383B82A04D7F4005E333D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		9B0383BA2A04D7F6005E333D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		9BB770FE2A0E1E8100C14987 /* BillValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillValidationError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +55,7 @@
 			children = (
 				9B0383B62A04D7F4005E333D /* JourneysSquadApp.swift */,
 				9B0383B82A04D7F4005E333D /* ContentView.swift */,
+				9BB771002A0E1E9100C14987 /* Model */,
 				9B0383BA2A04D7F6005E333D /* Assets.xcassets */,
 				9B0383BC2A04D7F6005E333D /* Preview Content */,
 			);
@@ -65,6 +68,14 @@
 				9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		9BB771002A0E1E9100C14987 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				9BB770FE2A0E1E8100C14987 /* BillValidationError.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -160,6 +171,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9BB770FF2A0E1E8100C14987 /* BillValidationError.swift in Sources */,
 				9B0383B92A04D7F4005E333D /* ContentView.swift in Sources */,
 				9B0383B72A04D7F4005E333D /* JourneysSquadApp.swift in Sources */,
 			);

--- a/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
+++ b/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
@@ -11,7 +11,8 @@
 		9B0383B92A04D7F4005E333D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0383B82A04D7F4005E333D /* ContentView.swift */; };
 		9B0383BB2A04D7F6005E333D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BA2A04D7F6005E333D /* Assets.xcassets */; };
 		9B0383BE2A04D7F6005E333D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */; };
-		9B1DBD982A0E2EE40082999A /* JourneysSquadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1DBD972A0E2EE40082999A /* JourneysSquadTests.swift */; };
+		9B1DBD982A0E2EE40082999A /* BillValidationErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1DBD972A0E2EE40082999A /* BillValidationErrorTests.swift */; };
+		9B1DBD9F2A0E31E40082999A /* BillValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB770FE2A0E1E8100C14987 /* BillValidationError.swift */; };
 		9BB770FF2A0E1E8100C14987 /* BillValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB770FE2A0E1E8100C14987 /* BillValidationError.swift */; };
 /* End PBXBuildFile section */
 
@@ -32,7 +33,7 @@
 		9B0383BA2A04D7F6005E333D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		9B1DBD952A0E2EE40082999A /* JourneysSquadTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JourneysSquadTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		9B1DBD972A0E2EE40082999A /* JourneysSquadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneysSquadTests.swift; sourceTree = "<group>"; };
+		9B1DBD972A0E2EE40082999A /* BillValidationErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillValidationErrorTests.swift; sourceTree = "<group>"; };
 		9BB770FE2A0E1E8100C14987 /* BillValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillValidationError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -95,9 +96,17 @@
 		9B1DBD962A0E2EE40082999A /* JourneysSquadTests */ = {
 			isa = PBXGroup;
 			children = (
-				9B1DBD972A0E2EE40082999A /* JourneysSquadTests.swift */,
+				9B1DBD9E2A0E30ED0082999A /* Model */,
 			);
 			path = JourneysSquadTests;
+			sourceTree = "<group>";
+		};
+		9B1DBD9E2A0E30ED0082999A /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				9B1DBD972A0E2EE40082999A /* BillValidationErrorTests.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		9BB771002A0E1E9100C14987 /* Model */ = {
@@ -241,7 +250,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9B1DBD982A0E2EE40082999A /* JourneysSquadTests.swift in Sources */,
+				9B1DBD9F2A0E31E40082999A /* BillValidationError.swift in Sources */,
+				9B1DBD982A0E2EE40082999A /* BillValidationErrorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
+++ b/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
@@ -11,8 +11,19 @@
 		9B0383B92A04D7F4005E333D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0383B82A04D7F4005E333D /* ContentView.swift */; };
 		9B0383BB2A04D7F6005E333D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BA2A04D7F6005E333D /* Assets.xcassets */; };
 		9B0383BE2A04D7F6005E333D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */; };
+		9B1DBD982A0E2EE40082999A /* JourneysSquadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1DBD972A0E2EE40082999A /* JourneysSquadTests.swift */; };
 		9BB770FF2A0E1E8100C14987 /* BillValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB770FE2A0E1E8100C14987 /* BillValidationError.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		9B1DBD992A0E2EE50082999A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9B0383AB2A04D7F4005E333D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9B0383B22A04D7F4005E333D;
+			remoteInfo = JourneysSquad;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		9B0383B32A04D7F4005E333D /* JourneysSquad.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JourneysSquad.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -20,11 +31,20 @@
 		9B0383B82A04D7F4005E333D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		9B0383BA2A04D7F6005E333D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		9B1DBD952A0E2EE40082999A /* JourneysSquadTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JourneysSquadTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B1DBD972A0E2EE40082999A /* JourneysSquadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneysSquadTests.swift; sourceTree = "<group>"; };
 		9BB770FE2A0E1E8100C14987 /* BillValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillValidationError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		9B0383B02A04D7F4005E333D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9B1DBD922A0E2EE40082999A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -38,6 +58,7 @@
 			isa = PBXGroup;
 			children = (
 				9B0383B52A04D7F4005E333D /* JourneysSquad */,
+				9B1DBD962A0E2EE40082999A /* JourneysSquadTests */,
 				9B0383B42A04D7F4005E333D /* Products */,
 			);
 			sourceTree = "<group>";
@@ -46,6 +67,7 @@
 			isa = PBXGroup;
 			children = (
 				9B0383B32A04D7F4005E333D /* JourneysSquad.app */,
+				9B1DBD952A0E2EE40082999A /* JourneysSquadTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -68,6 +90,14 @@
 				9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		9B1DBD962A0E2EE40082999A /* JourneysSquadTests */ = {
+			isa = PBXGroup;
+			children = (
+				9B1DBD972A0E2EE40082999A /* JourneysSquadTests.swift */,
+			);
+			path = JourneysSquadTests;
 			sourceTree = "<group>";
 		};
 		9BB771002A0E1E9100C14987 /* Model */ = {
@@ -99,6 +129,24 @@
 			productReference = 9B0383B32A04D7F4005E333D /* JourneysSquad.app */;
 			productType = "com.apple.product-type.application";
 		};
+		9B1DBD942A0E2EE40082999A /* JourneysSquadTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9B1DBD9D2A0E2EE50082999A /* Build configuration list for PBXNativeTarget "JourneysSquadTests" */;
+			buildPhases = (
+				9B1DBD912A0E2EE40082999A /* Sources */,
+				9B1DBD922A0E2EE40082999A /* Frameworks */,
+				9B1DBD932A0E2EE40082999A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9B1DBD9A2A0E2EE50082999A /* PBXTargetDependency */,
+			);
+			name = JourneysSquadTests;
+			productName = JourneysSquadTests;
+			productReference = 9B1DBD952A0E2EE40082999A /* JourneysSquadTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -111,6 +159,10 @@
 				TargetAttributes = {
 					9B0383B22A04D7F4005E333D = {
 						CreatedOnToolsVersion = 14.3;
+					};
+					9B1DBD942A0E2EE40082999A = {
+						CreatedOnToolsVersion = 14.3;
+						TestTargetID = 9B0383B22A04D7F4005E333D;
 					};
 				};
 			};
@@ -128,6 +180,7 @@
 			projectRoot = "";
 			targets = (
 				9B0383B22A04D7F4005E333D /* JourneysSquad */,
+				9B1DBD942A0E2EE40082999A /* JourneysSquadTests */,
 			);
 		};
 /* End PBXProject section */
@@ -139,6 +192,13 @@
 			files = (
 				9B0383BE2A04D7F6005E333D /* Preview Assets.xcassets in Resources */,
 				9B0383BB2A04D7F6005E333D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9B1DBD932A0E2EE40082999A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -177,7 +237,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9B1DBD912A0E2EE40082999A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9B1DBD982A0E2EE40082999A /* JourneysSquadTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9B1DBD9A2A0E2EE50082999A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9B0383B22A04D7F4005E333D /* JourneysSquad */;
+			targetProxy = 9B1DBD992A0E2EE50082999A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		9B0383BF2A04D7F6005E333D /* Debug */ = {
@@ -362,6 +438,48 @@
 			};
 			name = Release;
 		};
+		9B1DBD9B2A0E2EE50082999A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 0;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.link-team-project.iOS.JourneysSquadTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/JourneysSquad.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/JourneysSquad";
+			};
+			name = Debug;
+		};
+		9B1DBD9C2A0E2EE50082999A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 0;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.link-team-project.iOS.JourneysSquadTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/JourneysSquad.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/JourneysSquad";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -379,6 +497,15 @@
 			buildConfigurations = (
 				9B0383C22A04D7F6005E333D /* Debug */,
 				9B0383C32A04D7F6005E333D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9B1DBD9D2A0E2EE50082999A /* Build configuration list for PBXNativeTarget "JourneysSquadTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9B1DBD9B2A0E2EE50082999A /* Debug */,
+				9B1DBD9C2A0E2EE50082999A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/JourneysSquad/JourneysSquad.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/JourneysSquad/JourneysSquad.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
+++ b/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
@@ -1,8 +1,10 @@
 import Foundation
 /// Indicates error that can be caused by incorrect input data for the bill.
 enum BillValidationError: LocalizedError {
-    /// Indicates invalid participant's name.
-    case invalidParticipantName(String)
+    /// Indicates too long participant's name.
+    case tooLongName
+    /// Occurs when the participant's name doesn't contain no one letter.
+    case noOneLetterInName(String)
     /// Occurs when negative value is passed for fields that  can't be such.
     case negativeValue(Decimal)
     /// Occurs when the number of decimal places is greater than two.
@@ -16,18 +18,20 @@ enum BillValidationError: LocalizedError {
     /// The text message to output according to the error.
     var errorDescription: String? {
         switch self {
-        case let .invalidParticipantName(participant):
-            return "Invalid participant name: \(participant)."
+        case .tooLongName:
+            return "The maximum name length is 50 characters."
+        case let .noOneLetterInName(incorrectName):
+            return "The name: \(incorrectName) doesn't contain no one letter."
         case let .negativeValue(negativeSum):
             return "The money can't be negative: \(negativeSum)."
-        case let .invalidFormatOfSum(invalidSum):
-            return "Invalid format of the currency: \(invalidSum). Maximum accuracy is two decimal places."
+        case let .invalidFormatOfSum(invalidFormattedSum):
+            return "Invalid format of the currency: \(invalidFormattedSum). Maximum accuracy is two decimal places."
         case .zeroSumOfBill:
             return "The sum of bill can't be equal to zero."
         case .balanceIsViolated:
-            return "The sum of the bill must equal the sum of all the participants' sums."
-        case let .futureDate(date):
-            return "Error! This is a date in the future: \(date) ."
+            return "The sum of the bill must equal the sum of all the participants's sums."
+        case let .futureDate(futureDate):
+            return "Error! This is a date in the future: \(futureDate)."
         }
     }
 }

--- a/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
+++ b/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
@@ -1,0 +1,33 @@
+import Foundation
+/// Indicates error that can be caused by incorrect input data for the bill.
+enum BillValidationError: LocalizedError {
+    /// Indicates invalid participant's name.
+    case invalidParticipantName(String)
+    /// Occurs when negative value is passed for fields that  can't be such.
+    case negativeValue(Decimal)
+    /// Occurs when the number of decimal places is greater than two.
+    case invalidFormatOfSum(Decimal)
+    /// Indicates, that  the overall sum of the bill is equal to zero.
+    case zeroSumOfBill
+    /// Indicates that the overall sum of the bill isn't equal to the sum of the participants's sums.
+    case balanceIsViolated
+    /// Occurs when the input date is in the future.
+    case futureDate(Date)
+    /// The text message to output according to the error.
+    var errorDescription: String? {
+        switch self {
+        case let .invalidParticipantName(participant):
+            return "Invalid participant name: \(participant)."
+        case let .negativeValue(negativeSum):
+            return "The money can't be negative: \(negativeSum)."
+        case let .invalidFormatOfSum(invalidSum):
+            return "Invalid format of the currency: \(invalidSum). Maximum accuracy is two decimal places."
+        case .zeroSumOfBill:
+            return "The sum of bill can't be equal to zero."
+        case .balanceIsViolated:
+            return "The sum of the bill must equal the sum of all the participants' sums."
+        case let .futureDate(date):
+            return "Error! This is a date in the future: \(date) ."
+        }
+    }
+}

--- a/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
+++ b/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+
+final class BillValidationErrorTests: XCTestCase {
+    func testErrorDescriptionPresentsInAPIForTooLongError() {
+        _ = BillValidationError.tooLongName.errorDescription
+    }
+
+    func testErrorDescriptionPresentsInAPIForInvalidParticipantNameError() {
+        _ = BillValidationError.noOneLetterInName("#@").errorDescription
+    }
+
+    func testErrorDescriptionPresentsInAPIFornegativeValueError() {
+        _ = BillValidationError.balanceIsViolated.errorDescription
+    }
+
+    func testErrorDescriptionPresentsInAPIForNegativeValueError() {
+        _ = BillValidationError.negativeValue(10).errorDescription
+    }
+
+    func testErrorDescriptionPresentsInAPIForInvalidFormatOfSumError() {
+        _ = BillValidationError.invalidFormatOfSum(10).errorDescription
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForTooLondNameError() {
+        XCTAssertEqual(BillValidationError.tooLongName.errorDescription,
+                       "The maximum name length is 50 characters.")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForNoOneLetterInNameError() {
+        let incorrectName = "#@"
+        XCTAssertEqual(BillValidationError.noOneLetterInName(incorrectName).errorDescription,
+                       "The name: \(incorrectName) doesn't contain no one letter.")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForNegativeValueError() {
+        let negativeSum: Decimal = -4
+        XCTAssertEqual(BillValidationError.negativeValue(negativeSum).errorDescription,
+                       "The money can't be negative: \(negativeSum).")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForInvalidFormatOfSumError() {
+        let invalidFormattedSum: Decimal = 1.123
+        XCTAssertEqual(
+            BillValidationError.invalidFormatOfSum(invalidFormattedSum).errorDescription,
+            """
+            Invalid format of the currency: \(invalidFormattedSum). Maximum accuracy is two decimal places.
+            """
+        )
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForZeroSumOfBillError() {
+        XCTAssertEqual(BillValidationError.zeroSumOfBill.errorDescription,
+                       "The sum of bill can't be equal to zero.")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForBalanceIsViolatedError() {
+        XCTAssertEqual(BillValidationError.balanceIsViolated.errorDescription,
+                       "The sum of the bill must equal the sum of all the participants's sums.")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForfutureDateError() {
+        let futureDate = Date.now + 10
+        XCTAssertEqual(BillValidationError.futureDate(futureDate).errorDescription,
+                       "Error! This is a date in the future: \(futureDate).")
+    }
+}


### PR DESCRIPTION
# What 

Added enum `BillValidationError` with errors that can be caused by incorrect input data for the bill's fields.

# Why 

It's part of the work on issue #16. 

# How 

- Added enum `BillValidationError` with necessary error cases that listed in the [_Set of Errors_](https://github.com/ios-course/link-team-project/issues/16#:~:text=in%20the%20future.-,Set%20of%20Errors,-invalidParticipantName%20%2D%20indicates%20invalid) section.

- Added JourneySquadTest Target with next settings: 
  - Supported Destinations - iPhone only
  - Deployment info - 16.0
  - Target Device Families - iPhone
  - iOS Deployment Target - iOS 16.0
  - Current Project Version - 0
  - Marketing version - 0 

- Added tests for `errorDescription` property of the `BillValidationError`. 
