### PR TITLE
Add `BillValidationError`. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 - Build scheme for JourneySquad target.
+- `BillValidationError` type.

--- a/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
+++ b/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		9B0383B92A04D7F4005E333D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0383B82A04D7F4005E333D /* ContentView.swift */; };
 		9B0383BB2A04D7F6005E333D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BA2A04D7F6005E333D /* Assets.xcassets */; };
 		9B0383BE2A04D7F6005E333D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */; };
+		9BF8522D2A0F6DA10000E0C0 /* BillValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8522C2A0F6DA10000E0C0 /* BillValidationError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,6 +31,7 @@
 		9B0383BA2A04D7F6005E333D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		9B1DBD952A0E2EE40082999A /* JourneysSquadTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JourneysSquadTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9BF8522C2A0F6DA10000E0C0 /* BillValidationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BillValidationError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +73,7 @@
 		9B0383B52A04D7F4005E333D /* JourneysSquad */ = {
 			isa = PBXGroup;
 			children = (
+				9BF8522B2A0F6DA10000E0C0 /* Model */,
 				9B0383B62A04D7F4005E333D /* JourneysSquadApp.swift */,
 				9B0383B82A04D7F4005E333D /* ContentView.swift */,
 				9B0383BA2A04D7F6005E333D /* Assets.xcassets */,
@@ -92,6 +95,14 @@
 			children = (
 			);
 			path = JourneysSquadTests;
+			sourceTree = "<group>";
+		};
+		9BF8522B2A0F6DA10000E0C0 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				9BF8522C2A0F6DA10000E0C0 /* BillValidationError.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -218,6 +229,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9B0383B92A04D7F4005E333D /* ContentView.swift in Sources */,
+				9BF8522D2A0F6DA10000E0C0 /* BillValidationError.swift in Sources */,
 				9B0383B72A04D7F4005E333D /* JourneysSquadApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
+++ b/JourneysSquad/JourneysSquad.xcodeproj/project.pbxproj
@@ -11,7 +11,9 @@
 		9B0383B92A04D7F4005E333D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0383B82A04D7F4005E333D /* ContentView.swift */; };
 		9B0383BB2A04D7F6005E333D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BA2A04D7F6005E333D /* Assets.xcassets */; };
 		9B0383BE2A04D7F6005E333D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */; };
-		9BF8522D2A0F6DA10000E0C0 /* BillValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF8522C2A0F6DA10000E0C0 /* BillValidationError.swift */; };
+		9B1DBD982A0E2EE40082999A /* BillValidationErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1DBD972A0E2EE40082999A /* BillValidationErrorTests.swift */; };
+		9BF852312A0F6E7E0000E0C0 /* BillValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF852302A0F6E7E0000E0C0 /* BillValidationError.swift */; };
+		9BF852322A0F6E850000E0C0 /* BillValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF852302A0F6E7E0000E0C0 /* BillValidationError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,7 +33,8 @@
 		9B0383BA2A04D7F6005E333D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9B0383BD2A04D7F6005E333D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		9B1DBD952A0E2EE40082999A /* JourneysSquadTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JourneysSquadTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		9BF8522C2A0F6DA10000E0C0 /* BillValidationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BillValidationError.swift; sourceTree = "<group>"; };
+		9B1DBD972A0E2EE40082999A /* BillValidationErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillValidationErrorTests.swift; sourceTree = "<group>"; };
+		9BF852302A0F6E7E0000E0C0 /* BillValidationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BillValidationError.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,7 +76,7 @@
 		9B0383B52A04D7F4005E333D /* JourneysSquad */ = {
 			isa = PBXGroup;
 			children = (
-				9BF8522B2A0F6DA10000E0C0 /* Model */,
+				9BF8522F2A0F6E7E0000E0C0 /* Model */,
 				9B0383B62A04D7F4005E333D /* JourneysSquadApp.swift */,
 				9B0383B82A04D7F4005E333D /* ContentView.swift */,
 				9B0383BA2A04D7F6005E333D /* Assets.xcassets */,
@@ -93,14 +96,23 @@
 		9B1DBD962A0E2EE40082999A /* JourneysSquadTests */ = {
 			isa = PBXGroup;
 			children = (
+				9B1DBD9E2A0E30ED0082999A /* Model */,
 			);
 			path = JourneysSquadTests;
 			sourceTree = "<group>";
 		};
-		9BF8522B2A0F6DA10000E0C0 /* Model */ = {
+		9B1DBD9E2A0E30ED0082999A /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				9BF8522C2A0F6DA10000E0C0 /* BillValidationError.swift */,
+				9B1DBD972A0E2EE40082999A /* BillValidationErrorTests.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		9BF8522F2A0F6E7E0000E0C0 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				9BF852302A0F6E7E0000E0C0 /* BillValidationError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -229,7 +241,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9B0383B92A04D7F4005E333D /* ContentView.swift in Sources */,
-				9BF8522D2A0F6DA10000E0C0 /* BillValidationError.swift in Sources */,
+				9BF852312A0F6E7E0000E0C0 /* BillValidationError.swift in Sources */,
 				9B0383B72A04D7F4005E333D /* JourneysSquadApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -238,6 +250,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9BF852322A0F6E850000E0C0 /* BillValidationError.swift in Sources */,
+				9B1DBD982A0E2EE40082999A /* BillValidationErrorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JourneysSquad/JourneysSquad/ContentView.swift
+++ b/JourneysSquad/JourneysSquad/ContentView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {}
+        VStack {
+        }
     }
 }
 

--- a/JourneysSquad/JourneysSquad/ContentView.swift
+++ b/JourneysSquad/JourneysSquad/ContentView.swift
@@ -2,8 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-        }
+        VStack {}
     }
 }
 

--- a/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
+++ b/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
@@ -1,0 +1,37 @@
+import Foundation
+/// Indicates error that can be caused by incorrect input data for the bill.
+enum BillValidationError: LocalizedError {
+    /// Indicates too long participant's name.
+    case tooLongName
+    /// Occurs when the participant's name doesn't contain no one letter.
+    case noOneLetterInName(String)
+    /// Occurs when negative value is passed for fields that  can't be such.
+    case negativeValue(Decimal)
+    /// Occurs when the number of decimal places is greater than two.
+    case invalidFormatOfSum(Decimal)
+    /// Indicates, that  the overall sum of the bill is equal to zero.
+    case zeroSumOfBill
+    /// Indicates that the overall sum of the bill isn't equal to the sum of the participants's sums.
+    case balanceIsViolated
+    /// Occurs when the input date is in the future.
+    case futureDate(Date)
+    /// The text message to output according to the error.
+    var errorDescription: String? {
+        switch self {
+        case .tooLongName:
+            return "The maximum name length is 50 characters."
+        case let .noOneLetterInName(incorrectName):
+            return "The name: \(incorrectName) doesn't contain no one letter."
+        case let .negativeValue(negativeSum):
+            return "The money can't be negative: \(negativeSum)."
+        case let .invalidFormatOfSum(invalidFormattedSum):
+            return "Invalid format of the currency: \(invalidFormattedSum). Maximum accuracy is two decimal places."
+        case .zeroSumOfBill:
+            return "The sum of bill can't be equal to zero."
+        case .balanceIsViolated:
+            return "The sum of the bill must equal the sum of all the participants's sums."
+        case let .futureDate(futureDate):
+            return "Error! This is a date in the future: \(futureDate)."
+        }
+    }
+}

--- a/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
+++ b/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
@@ -5,12 +5,12 @@ enum BillValidationError: Error {
     /// Indicates too long participant's name.
     ///
     /// - Parameter name: The name that exceeds allowed length and causes the error.
-    case tooLongParticipantName(name: String)
+    case tooLongPersonName(name: String)
 
     /// Occurs when the participant's name contains only spaces or no one character.
     ///
     /// - Parameter name: The name that causes the error.
-    case emptyParticipantName(name: String)
+    case emptyPersonName(name: String)
 
     /// Occurs when a negative number is passed for fields that reflects the amount of money and can't be such.
     ///
@@ -20,37 +20,37 @@ enum BillValidationError: Error {
     /// Occurs when the amount of decimal places in the number that is used to note money is greater than two.
     ///
     /// - Parameter number: The number whose format causes the error.
-    case invalidFormatOfMoneyAmount(number: Decimal)
+    case moreThanTwoDecimalPlacesForMoney(amount: Decimal)
 
     /// Indicates, that the overall sum of the bill is less than or equal to zero.
     ///
     /// - Parameter sum: The sum of the bill that causes the error.
-    case incorrectSumOfBill(sum: Decimal)
+    case invalidSumOfBill(sum: Decimal)
 
-    /// Indicates that the overall sum of the bill isn't equal to the sum of the participants's sums.
-    case equalityIsViolated
+    /// Indicates that the sum of the bill doesn't equal the sum of all the participants's pays.
+    case incorrectEstimatedSumOfTheBill
 
     /// Occurs when the input date is in the future.
-    case futureDate(Date)
+    case theDateIsInFuture(Date)
 }
 
 extension BillValidationError: LocalizedError {
     var errorDescription: String? {
         switch self {
-        case let .tooLongParticipantName(tooLongName):
-            return "The name length exceeds 50 characters: \(tooLongName)."
-        case let .emptyParticipantName(emptyName):
-            return "The name: \(emptyName) contains only spaces or no one sign."
+        case let .tooLongPersonName(tooLongName):
+            return "The length of the person's name exceeds the maximum allowed length: \(tooLongName)."
+        case let .emptyPersonName(emptyPersonName):
+            return "The name: \(emptyPersonName) contains only spaces or no one sign."
         case let .negativeAmountOfMoney(negativeAmount):
-            return "The money can't be negative: \(negativeAmount)."
-        case let .invalidFormatOfMoneyAmount(invalidFormattedNumber):
-            return "Invalid format of money amount: \(invalidFormattedNumber). Maximum accuracy is two decimal places."
-        case let .incorrectSumOfBill(incorrectSum):
-            return "Sum: \(incorrectSum) is less than or equal to zero."
-        case .equalityIsViolated:
-            return "The sum of the bill must equal the sum of all the participants's sums."
-        case let .futureDate(futureDate):
-            return "This is a date in the future: \(futureDate)."
+            return "The amount of money <= 0: \(negativeAmount)."
+        case let .moreThanTwoDecimalPlacesForMoney(number):
+            return "The given amount of money has accuracy more than two decimal places: \(number)."
+        case let .invalidSumOfBill(invalidSum):
+            return "Sum of bill is less than or equal to zero: \(invalidSum)."
+        case .incorrectEstimatedSumOfTheBill:
+            return "The sum of the bill doesn't equal the sum of all the participants's pays."
+        case let .theDateIsInFuture(dateInFuture):
+            return "This is a date in the future: \(dateInFuture)."
         }
     }
 }

--- a/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
+++ b/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
@@ -12,7 +12,7 @@ enum BillValidationError: Error {
     /// - Parameter name: The name that causes the error.
     case emptyPersonName(name: String)
 
-    /// Occurs when a negative number is passed for fields that reflects the amount of money and can't be such.
+    /// Occurs when a passed amount of money is negative number.
     ///
     /// - Parameter number: The negative number that causes the error.
     case negativeAmountOfMoney(number: Decimal)

--- a/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
+++ b/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
@@ -1,37 +1,56 @@
 import Foundation
-/// Indicates error that can be caused by incorrect input data for the bill.
-enum BillValidationError: LocalizedError {
+
+/// An error that can be caused by incorrect input data for the bill.
+enum BillValidationError: Error {
     /// Indicates too long participant's name.
-    case tooLongName
-    /// Occurs when the participant's name doesn't contain no one letter.
-    case noOneLetterInName(String)
-    /// Occurs when negative value is passed for fields that  can't be such.
-    case negativeValue(Decimal)
-    /// Occurs when the number of decimal places is greater than two.
-    case invalidFormatOfSum(Decimal)
-    /// Indicates, that  the overall sum of the bill is equal to zero.
-    case zeroSumOfBill
+    ///
+    /// - Parameter name: The name that exceeds allowed length and causes the error.
+    case tooLongParticipantName(name: String)
+
+    /// Occurs when the participant's name contains only spaces or no one character.
+    ///
+    /// - Parameter name: The name that causes the error.
+    case emptyParticipantName(name: String)
+
+    /// Occurs when a negative number is passed for fields that reflects the amount of money and can't be such.
+    ///
+    /// - Parameter number: The negative number that causes the error.
+    case negativeAmountOfMoney(number: Decimal)
+
+    /// Occurs when the amount of decimal places in the number that is used to note money is greater than two.
+    ///
+    /// - Parameter number: The number whose format causes the error.
+    case invalidFormatOfMoneyAmount(number: Decimal)
+
+    /// Indicates, that the overall sum of the bill is less than or equal to zero.
+    ///
+    /// - Parameter sum: The sum of the bill that causes the error.
+    case incorrectSumOfBill(sum: Decimal)
+
     /// Indicates that the overall sum of the bill isn't equal to the sum of the participants's sums.
-    case balanceIsViolated
+    case equalityIsViolated
+
     /// Occurs when the input date is in the future.
     case futureDate(Date)
-    /// The text message to output according to the error.
+}
+
+extension BillValidationError: LocalizedError {
     var errorDescription: String? {
         switch self {
-        case .tooLongName:
-            return "The maximum name length is 50 characters."
-        case let .noOneLetterInName(incorrectName):
-            return "The name: \(incorrectName) doesn't contain no one letter."
-        case let .negativeValue(negativeSum):
-            return "The money can't be negative: \(negativeSum)."
-        case let .invalidFormatOfSum(invalidFormattedSum):
-            return "Invalid format of the currency: \(invalidFormattedSum). Maximum accuracy is two decimal places."
-        case .zeroSumOfBill:
-            return "The sum of bill can't be equal to zero."
-        case .balanceIsViolated:
+        case let .tooLongParticipantName(tooLongName):
+            return "The name length exceeds 50 characters: \(tooLongName)."
+        case let .emptyParticipantName(emptyName):
+            return "The name: \(emptyName) contains only spaces or no one sign."
+        case let .negativeAmountOfMoney(negativeAmount):
+            return "The money can't be negative: \(negativeAmount)."
+        case let .invalidFormatOfMoneyAmount(invalidFormattedNumber):
+            return "Invalid format of money amount: \(invalidFormattedNumber). Maximum accuracy is two decimal places."
+        case let .incorrectSumOfBill(incorrectSum):
+            return "Sum: \(incorrectSum) is less than or equal to zero."
+        case .equalityIsViolated:
             return "The sum of the bill must equal the sum of all the participants's sums."
         case let .futureDate(futureDate):
-            return "Error! This is a date in the future: \(futureDate)."
+            return "This is a date in the future: \(futureDate)."
         }
     }
 }

--- a/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
+++ b/JourneysSquad/JourneysSquad/Model/BillValidationError.swift
@@ -2,12 +2,12 @@ import Foundation
 
 /// An error that can be caused by incorrect input data for the bill.
 enum BillValidationError: Error {
-    /// Indicates too long participant's name.
+    /// Indicates too long person's name.
     ///
     /// - Parameter name: The name that exceeds allowed length and causes the error.
     case tooLongPersonName(name: String)
 
-    /// Occurs when the participant's name contains only spaces or no one character.
+    /// Occurs when the person's name contains only spaces or no one character.
     ///
     /// - Parameter name: The name that causes the error.
     case emptyPersonName(name: String)
@@ -27,7 +27,7 @@ enum BillValidationError: Error {
     /// - Parameter sum: The sum of the bill that causes the error.
     case invalidSumOfBill(sum: Decimal)
 
-    /// Indicates that the sum of the bill doesn't equal the sum of all the participants's pays.
+    /// Indicates that the sum of the bill doesn't equal the sum of all the person's pays.
     case incorrectEstimatedSumOfTheBill
 
     /// Occurs when the input date is in the future.
@@ -40,7 +40,7 @@ extension BillValidationError: LocalizedError {
         case let .tooLongPersonName(tooLongName):
             return "The length of the person's name exceeds the maximum allowed length: \(tooLongName)."
         case let .emptyPersonName(emptyPersonName):
-            return "The name: \(emptyPersonName) contains only spaces or no one sign."
+            return "The name: \(emptyPersonName) contains only spaces or no one character."
         case let .negativeAmountOfMoney(negativeAmount):
             return "The amount of money <= 0: \(negativeAmount)."
         case let .moreThanTwoDecimalPlacesForMoney(number):
@@ -48,7 +48,7 @@ extension BillValidationError: LocalizedError {
         case let .invalidSumOfBill(invalidSum):
             return "Sum of bill is less than or equal to zero: \(invalidSum)."
         case .incorrectEstimatedSumOfTheBill:
-            return "The sum of the bill doesn't equal the sum of all the participants's pays."
+            return "The sum of the bill doesn't equal the sum of all the person's pays."
         case let .theDateIsInFuture(dateInFuture):
             return "This is a date in the future: \(dateInFuture)."
         }

--- a/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
+++ b/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+
+final class BillValidationErrorTests: XCTestCase {
+    func testErrorDescriptionPresentsInAPIForTooLongError() {
+        _ = BillValidationError.tooLongName.errorDescription
+    }
+
+    func testErrorDescriptionPresentsInAPIForInvalidParticipantNameError() {
+        _ = BillValidationError.noOneLetterInName("#@").errorDescription
+    }
+
+    func testErrorDescriptionPresentsInAPIFornegativeValueError() {
+        _ = BillValidationError.balanceIsViolated.errorDescription
+    }
+
+    func testErrorDescriptionPresentsInAPIForNegativeValueError() {
+        _ = BillValidationError.negativeValue(10).errorDescription
+    }
+
+    func testErrorDescriptionPresentsInAPIForInvalidFormatOfSumError() {
+        _ = BillValidationError.invalidFormatOfSum(10).errorDescription
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForTooLondNameError() {
+        XCTAssertEqual(BillValidationError.tooLongName.errorDescription,
+                       "The maximum name length is 50 characters.")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForNoOneLetterInNameError() {
+        let incorrectName = "#@"
+        XCTAssertEqual(BillValidationError.noOneLetterInName(incorrectName).errorDescription,
+                       "The name: \(incorrectName) doesn't contain no one letter.")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForNegativeValueError() {
+        let negativeSum: Decimal = -4
+        XCTAssertEqual(BillValidationError.negativeValue(negativeSum).errorDescription,
+                       "The money can't be negative: \(negativeSum).")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForInvalidFormatOfSumError() {
+        let invalidFormattedSum: Decimal = 1.123
+        XCTAssertEqual(
+            BillValidationError.invalidFormatOfSum(invalidFormattedSum).errorDescription,
+            """
+            Invalid format of the currency: \(invalidFormattedSum). Maximum accuracy is two decimal places.
+            """
+        )
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForZeroSumOfBillError() {
+        XCTAssertEqual(BillValidationError.zeroSumOfBill.errorDescription,
+                       "The sum of bill can't be equal to zero.")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForBalanceIsViolatedError() {
+        XCTAssertEqual(BillValidationError.balanceIsViolated.errorDescription,
+                       "The sum of the bill must equal the sum of all the participants's sums.")
+    }
+
+    func testErrorDescriptionReturnsCorrespondingMessageForfutureDateError() {
+        let futureDate = Date.now + 10
+        XCTAssertEqual(BillValidationError.futureDate(futureDate).errorDescription,
+                       "Error! This is a date in the future: \(futureDate).")
+    }
+}

--- a/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
+++ b/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
@@ -2,32 +2,40 @@ import XCTest
 
 final class BillValidationErrorTests: XCTestCase {
     func testErrorDescriptionPresentsInAPIForTooLongError() {
-        _ = BillValidationError.tooLongParticipantName(name: "Abu Ibn .....").errorDescription
+        _ = BillValidationError.tooLongParticipantName(name: "someLongName").errorDescription
         _ = BillValidationError.emptyParticipantName(name: " ").errorDescription
         _ = BillValidationError.negativeAmountOfMoney(number: 10).errorDescription
         _ = BillValidationError.invalidFormatOfMoneyAmount(number: 10.111).errorDescription
         _ = BillValidationError.incorrectSumOfBill(sum: 0)
         _ = BillValidationError.equalityIsViolated.errorDescription
     }
-
+    
     func testErrorDescriptionReturnsCorrespondingMessageForTooLongParticipantNameError() {
-        let longName = "Abu Ali Ibn ......"
-        XCTAssertEqual(BillValidationError.tooLongParticipantName(name: longName).errorDescription,
-                       "The name length exceeds 50 characters: \(longName).")
+        let name = "test"
+        
+        let expectedErrorDescription = "The name length exceeds 50 characters: \(name)."
+        
+        let actualErrorDescription = BillValidationError.tooLongParticipantName(name: name).errorDescription
+        
+        XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
-
+    
     func testErrorDescriptionReturnsCorrespondingMessageForEmptyNameError() {
         let emptyName = " "
-        XCTAssertEqual(BillValidationError.emptyParticipantName(name: emptyName).errorDescription,
-                       "The name: \(emptyName) contains only spaces or no one sign.")
+        
+        let expectedErrorDescription = "The name: \(emptyName) contains only spaces or no one sign."
+        
+        let actualErrorDescription = BillValidationError.emptyParticipantName(name: emptyName).errorDescription
+        
+        XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
-
+    
     func testErrorDescriptionReturnsCorrespondingMessageForNegativeAmountOfMoneyError() {
         let negativeAmount: Decimal = -4
         XCTAssertEqual(BillValidationError.negativeAmountOfMoney(number: negativeAmount).errorDescription,
                        "The money can't be negative: \(negativeAmount).")
     }
-
+    
     func testErrorDescriptionReturnsCorrespondingMessageForInvalidFormatOfNumberError() {
         let number: Decimal = 1.123
         XCTAssertEqual(
@@ -37,18 +45,18 @@ final class BillValidationErrorTests: XCTestCase {
             """
         )
     }
-
+    
     func testErrorDescriptionReturnsCorrespondingMessageForIncorrectSumOfBillError() {
         let incorrectSumOfBill: Decimal = 0
         XCTAssertEqual(BillValidationError.incorrectSumOfBill(sum: incorrectSumOfBill).errorDescription,
                        "Sum: \(incorrectSumOfBill) is less than or equal to zero.")
     }
-
+    
     func testErrorDescriptionReturnsCorrespondingMessageForEqualityIsViolatedError() {
         XCTAssertEqual(BillValidationError.equalityIsViolated.errorDescription,
                        "The sum of the bill must equal the sum of all the participants's sums.")
     }
-
+    
     func testErrorDescriptionReturnsCorrespondingMessageForFutureDateError() {
         let tenSecondsDuration: TimeInterval = 10
         let tenSecondsFromNowDate = Date.now + tenSecondsDuration

--- a/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
+++ b/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
@@ -2,49 +2,41 @@ import XCTest
 
 final class BillValidationErrorTests: XCTestCase {
     func testErrorDescriptionPresentsInAPI() {
-        _ = BillValidationError.tooLongPersonName(name: "someLongName").errorDescription
-        _ = BillValidationError.emptyPersonName(name: " ").errorDescription
-        _ = BillValidationError.negativeAmountOfMoney(number: -10).errorDescription
-        _ = BillValidationError.moreThanTwoDecimalPlacesForMoney(amount: 10.111).errorDescription
+        _ = BillValidationError.tooLongPersonName(name: "").errorDescription
+        _ = BillValidationError.emptyPersonName(name: "").errorDescription
+        _ = BillValidationError.negativeAmountOfMoney(number: 0).errorDescription
+        _ = BillValidationError.moreThanTwoDecimalPlacesForMoney(amount: 0).errorDescription
         _ = BillValidationError.invalidSumOfBill(sum: 0)
         _ = BillValidationError.incorrectEstimatedSumOfTheBill.errorDescription
     }
 
     func testErrorDescriptionReturnsCorrespondingMessageForTooLongPersonNameError() {
         let name = "test"
-
         let expectedErrorDescription = "The length of the person's name exceeds the maximum allowed length: \(name)."
-
         let actualErrorDescription = BillValidationError.tooLongPersonName(name: name).errorDescription
 
         XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
 
     func testErrorDescriptionReturnsCorrespondingMessageForEmptyPersonNameError() {
-        let name = " "
-
-        let expectedErrorDescription = "The name: \(name) contains only spaces or no one sign."
-
+        let name = ""
+        let expectedErrorDescription = "The name: \(name) contains only spaces or no one character."
         let actualErrorDescription = BillValidationError.emptyPersonName(name: name).errorDescription
 
         XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
 
     func testErrorDescriptionReturnsCorrespondingMessageForNegativeAmountOfMoneyError() {
-        let amount: Decimal = -4
-
+        let amount: Decimal = 0
         let expectedErrorDescription = "The amount of money <= 0: \(amount)."
-
         let actualErrorDescription = BillValidationError.negativeAmountOfMoney(number: amount).errorDescription
 
         XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
 
     func testErrorDescriptionReturnsCorrespondingMessageForMoreThanTwoDecimalPlacesForMoneyError() {
-        let amount: Decimal = 1.123
-
+        let amount: Decimal = 0
         let expectedErrorDescription = "The given amount of money has accuracy more than two decimal places: \(amount)."
-
         let actualErrorDescription =
             BillValidationError.moreThanTwoDecimalPlacesForMoney(amount: amount).errorDescription
 
@@ -53,17 +45,14 @@ final class BillValidationErrorTests: XCTestCase {
 
     func testErrorDescriptionReturnsCorrespondingMessageForInvalidSumOfBillError() {
         let sum: Decimal = 0
-
         let expectedErrorDescription = "Sum of bill is less than or equal to zero: \(sum)."
-
         let actualErrorDescription = BillValidationError.invalidSumOfBill(sum: sum).errorDescription
 
         XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
 
     func testErrorDescriptionReturnsCorrespondingMessageForIncorrectEstimatedSumOfTheBillError() {
-        let expectedErrorDescription = "The sum of the bill doesn't equal the sum of all the participants's pays."
-
+        let expectedErrorDescription = "The sum of the bill doesn't equal the sum of all the person's pays."
         let actualErrorDescription = BillValidationError.incorrectEstimatedSumOfTheBill.errorDescription
 
         XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
@@ -72,10 +61,10 @@ final class BillValidationErrorTests: XCTestCase {
     func testErrorDescriptionReturnsCorrespondingMessageForTheDateIsInFutureError() {
         let tenSecondsDuration: TimeInterval = 10
         let tenSecondsFromNowDate = Date.now + tenSecondsDuration
+        
+        let expectedErrorDescription = "This is a date in the future: \(tenSecondsFromNowDate)."
+        let actualErrorDescription = BillValidationError.theDateIsInFuture(tenSecondsFromNowDate).errorDescription
 
-        XCTAssertEqual(
-            BillValidationError.theDateIsInFuture(tenSecondsFromNowDate).errorDescription,
-            "This is a date in the future: \(tenSecondsFromNowDate)."
-        )
+        XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
 }

--- a/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
+++ b/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
@@ -61,7 +61,7 @@ final class BillValidationErrorTests: XCTestCase {
     func testErrorDescriptionReturnsCorrespondingMessageForTheDateIsInFutureError() {
         let tenSecondsDuration: TimeInterval = 10
         let tenSecondsFromNowDate = Date.now + tenSecondsDuration
-        
+
         let expectedErrorDescription = "This is a date in the future: \(tenSecondsFromNowDate)."
         let actualErrorDescription = BillValidationError.theDateIsInFuture(tenSecondsFromNowDate).errorDescription
 

--- a/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
+++ b/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
@@ -1,66 +1,81 @@
 import XCTest
 
 final class BillValidationErrorTests: XCTestCase {
-    func testErrorDescriptionPresentsInAPIForTooLongError() {
-        _ = BillValidationError.tooLongParticipantName(name: "someLongName").errorDescription
-        _ = BillValidationError.emptyParticipantName(name: " ").errorDescription
-        _ = BillValidationError.negativeAmountOfMoney(number: 10).errorDescription
-        _ = BillValidationError.invalidFormatOfMoneyAmount(number: 10.111).errorDescription
-        _ = BillValidationError.incorrectSumOfBill(sum: 0)
-        _ = BillValidationError.equalityIsViolated.errorDescription
+    func testErrorDescriptionPresentsInAPI() {
+        _ = BillValidationError.tooLongPersonName(name: "someLongName").errorDescription
+        _ = BillValidationError.emptyPersonName(name: " ").errorDescription
+        _ = BillValidationError.negativeAmountOfMoney(number: -10).errorDescription
+        _ = BillValidationError.moreThanTwoDecimalPlacesForMoney(amount: 10.111).errorDescription
+        _ = BillValidationError.invalidSumOfBill(sum: 0)
+        _ = BillValidationError.incorrectEstimatedSumOfTheBill.errorDescription
     }
-    
-    func testErrorDescriptionReturnsCorrespondingMessageForTooLongParticipantNameError() {
+
+    func testErrorDescriptionReturnsCorrespondingMessageForTooLongPersonNameError() {
         let name = "test"
-        
-        let expectedErrorDescription = "The name length exceeds 50 characters: \(name)."
-        
-        let actualErrorDescription = BillValidationError.tooLongParticipantName(name: name).errorDescription
-        
+
+        let expectedErrorDescription = "The length of the person's name exceeds the maximum allowed length: \(name)."
+
+        let actualErrorDescription = BillValidationError.tooLongPersonName(name: name).errorDescription
+
         XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
-    
-    func testErrorDescriptionReturnsCorrespondingMessageForEmptyNameError() {
-        let emptyName = " "
-        
-        let expectedErrorDescription = "The name: \(emptyName) contains only spaces or no one sign."
-        
-        let actualErrorDescription = BillValidationError.emptyParticipantName(name: emptyName).errorDescription
-        
+
+    func testErrorDescriptionReturnsCorrespondingMessageForEmptyPersonNameError() {
+        let name = " "
+
+        let expectedErrorDescription = "The name: \(name) contains only spaces or no one sign."
+
+        let actualErrorDescription = BillValidationError.emptyPersonName(name: name).errorDescription
+
         XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
-    
+
     func testErrorDescriptionReturnsCorrespondingMessageForNegativeAmountOfMoneyError() {
-        let negativeAmount: Decimal = -4
-        XCTAssertEqual(BillValidationError.negativeAmountOfMoney(number: negativeAmount).errorDescription,
-                       "The money can't be negative: \(negativeAmount).")
+        let amount: Decimal = -4
+
+        let expectedErrorDescription = "The amount of money <= 0: \(amount)."
+
+        let actualErrorDescription = BillValidationError.negativeAmountOfMoney(number: amount).errorDescription
+
+        XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
-    
-    func testErrorDescriptionReturnsCorrespondingMessageForInvalidFormatOfNumberError() {
-        let number: Decimal = 1.123
-        XCTAssertEqual(
-            BillValidationError.invalidFormatOfMoneyAmount(number: number).errorDescription,
-            """
-            Invalid format of money amount: \(number). Maximum accuracy is two decimal places.
-            """
-        )
+
+    func testErrorDescriptionReturnsCorrespondingMessageForMoreThanTwoDecimalPlacesForMoneyError() {
+        let amount: Decimal = 1.123
+
+        let expectedErrorDescription = "The given amount of money has accuracy more than two decimal places: \(amount)."
+
+        let actualErrorDescription =
+        BillValidationError.moreThanTwoDecimalPlacesForMoney(amount: amount).errorDescription
+
+        XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
-    
-    func testErrorDescriptionReturnsCorrespondingMessageForIncorrectSumOfBillError() {
-        let incorrectSumOfBill: Decimal = 0
-        XCTAssertEqual(BillValidationError.incorrectSumOfBill(sum: incorrectSumOfBill).errorDescription,
-                       "Sum: \(incorrectSumOfBill) is less than or equal to zero.")
+
+    func testErrorDescriptionReturnsCorrespondingMessageForInvalidSumOfBillError() {
+        let sum: Decimal = 0
+
+        let expectedErrorDescription = "Sum of bill is less than or equal to zero: \(sum)."
+
+        let actualErrorDescription = BillValidationError.invalidSumOfBill(sum: sum).errorDescription
+
+        XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
-    
-    func testErrorDescriptionReturnsCorrespondingMessageForEqualityIsViolatedError() {
-        XCTAssertEqual(BillValidationError.equalityIsViolated.errorDescription,
-                       "The sum of the bill must equal the sum of all the participants's sums.")
+
+    func testErrorDescriptionReturnsCorrespondingMessageForIncorrectEstimatedSumOfTheBillError() {
+        let expectedErrorDescription = "The sum of the bill doesn't equal the sum of all the participants's pays."
+
+        let actualErrorDescription = BillValidationError.incorrectEstimatedSumOfTheBill.errorDescription
+
+        XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }
-    
-    func testErrorDescriptionReturnsCorrespondingMessageForFutureDateError() {
+
+    func testErrorDescriptionReturnsCorrespondingMessageForTheDateIsInFutureError() {
         let tenSecondsDuration: TimeInterval = 10
         let tenSecondsFromNowDate = Date.now + tenSecondsDuration
-        XCTAssertEqual(BillValidationError.futureDate(tenSecondsFromNowDate).errorDescription,
-                       "This is a date in the future: \(tenSecondsFromNowDate).")
+
+        XCTAssertEqual(
+            BillValidationError.theDateIsInFuture(tenSecondsFromNowDate).errorDescription,
+            "This is a date in the future: \(tenSecondsFromNowDate)."
+        )
     }
 }

--- a/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
+++ b/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
@@ -46,7 +46,7 @@ final class BillValidationErrorTests: XCTestCase {
         let expectedErrorDescription = "The given amount of money has accuracy more than two decimal places: \(amount)."
 
         let actualErrorDescription =
-        BillValidationError.moreThanTwoDecimalPlacesForMoney(amount: amount).errorDescription
+            BillValidationError.moreThanTwoDecimalPlacesForMoney(amount: amount).errorDescription
 
         XCTAssertEqual(actualErrorDescription, expectedErrorDescription)
     }

--- a/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
+++ b/JourneysSquad/JourneysSquadTests/Model/BillValidationErrorTests.swift
@@ -2,65 +2,57 @@ import XCTest
 
 final class BillValidationErrorTests: XCTestCase {
     func testErrorDescriptionPresentsInAPIForTooLongError() {
-        _ = BillValidationError.tooLongName.errorDescription
+        _ = BillValidationError.tooLongParticipantName(name: "Abu Ibn .....").errorDescription
+        _ = BillValidationError.emptyParticipantName(name: " ").errorDescription
+        _ = BillValidationError.negativeAmountOfMoney(number: 10).errorDescription
+        _ = BillValidationError.invalidFormatOfMoneyAmount(number: 10.111).errorDescription
+        _ = BillValidationError.incorrectSumOfBill(sum: 0)
+        _ = BillValidationError.equalityIsViolated.errorDescription
     }
 
-    func testErrorDescriptionPresentsInAPIForInvalidParticipantNameError() {
-        _ = BillValidationError.noOneLetterInName("#@").errorDescription
+    func testErrorDescriptionReturnsCorrespondingMessageForTooLongParticipantNameError() {
+        let longName = "Abu Ali Ibn ......"
+        XCTAssertEqual(BillValidationError.tooLongParticipantName(name: longName).errorDescription,
+                       "The name length exceeds 50 characters: \(longName).")
     }
 
-    func testErrorDescriptionPresentsInAPIFornegativeValueError() {
-        _ = BillValidationError.balanceIsViolated.errorDescription
+    func testErrorDescriptionReturnsCorrespondingMessageForEmptyNameError() {
+        let emptyName = " "
+        XCTAssertEqual(BillValidationError.emptyParticipantName(name: emptyName).errorDescription,
+                       "The name: \(emptyName) contains only spaces or no one sign.")
     }
 
-    func testErrorDescriptionPresentsInAPIForNegativeValueError() {
-        _ = BillValidationError.negativeValue(10).errorDescription
+    func testErrorDescriptionReturnsCorrespondingMessageForNegativeAmountOfMoneyError() {
+        let negativeAmount: Decimal = -4
+        XCTAssertEqual(BillValidationError.negativeAmountOfMoney(number: negativeAmount).errorDescription,
+                       "The money can't be negative: \(negativeAmount).")
     }
 
-    func testErrorDescriptionPresentsInAPIForInvalidFormatOfSumError() {
-        _ = BillValidationError.invalidFormatOfSum(10).errorDescription
-    }
-
-    func testErrorDescriptionReturnsCorrespondingMessageForTooLondNameError() {
-        XCTAssertEqual(BillValidationError.tooLongName.errorDescription,
-                       "The maximum name length is 50 characters.")
-    }
-
-    func testErrorDescriptionReturnsCorrespondingMessageForNoOneLetterInNameError() {
-        let incorrectName = "#@"
-        XCTAssertEqual(BillValidationError.noOneLetterInName(incorrectName).errorDescription,
-                       "The name: \(incorrectName) doesn't contain no one letter.")
-    }
-
-    func testErrorDescriptionReturnsCorrespondingMessageForNegativeValueError() {
-        let negativeSum: Decimal = -4
-        XCTAssertEqual(BillValidationError.negativeValue(negativeSum).errorDescription,
-                       "The money can't be negative: \(negativeSum).")
-    }
-
-    func testErrorDescriptionReturnsCorrespondingMessageForInvalidFormatOfSumError() {
-        let invalidFormattedSum: Decimal = 1.123
+    func testErrorDescriptionReturnsCorrespondingMessageForInvalidFormatOfNumberError() {
+        let number: Decimal = 1.123
         XCTAssertEqual(
-            BillValidationError.invalidFormatOfSum(invalidFormattedSum).errorDescription,
+            BillValidationError.invalidFormatOfMoneyAmount(number: number).errorDescription,
             """
-            Invalid format of the currency: \(invalidFormattedSum). Maximum accuracy is two decimal places.
+            Invalid format of money amount: \(number). Maximum accuracy is two decimal places.
             """
         )
     }
 
-    func testErrorDescriptionReturnsCorrespondingMessageForZeroSumOfBillError() {
-        XCTAssertEqual(BillValidationError.zeroSumOfBill.errorDescription,
-                       "The sum of bill can't be equal to zero.")
+    func testErrorDescriptionReturnsCorrespondingMessageForIncorrectSumOfBillError() {
+        let incorrectSumOfBill: Decimal = 0
+        XCTAssertEqual(BillValidationError.incorrectSumOfBill(sum: incorrectSumOfBill).errorDescription,
+                       "Sum: \(incorrectSumOfBill) is less than or equal to zero.")
     }
 
-    func testErrorDescriptionReturnsCorrespondingMessageForBalanceIsViolatedError() {
-        XCTAssertEqual(BillValidationError.balanceIsViolated.errorDescription,
+    func testErrorDescriptionReturnsCorrespondingMessageForEqualityIsViolatedError() {
+        XCTAssertEqual(BillValidationError.equalityIsViolated.errorDescription,
                        "The sum of the bill must equal the sum of all the participants's sums.")
     }
 
-    func testErrorDescriptionReturnsCorrespondingMessageForfutureDateError() {
-        let futureDate = Date.now + 10
-        XCTAssertEqual(BillValidationError.futureDate(futureDate).errorDescription,
-                       "Error! This is a date in the future: \(futureDate).")
+    func testErrorDescriptionReturnsCorrespondingMessageForFutureDateError() {
+        let tenSecondsDuration: TimeInterval = 10
+        let tenSecondsFromNowDate = Date.now + tenSecondsDuration
+        XCTAssertEqual(BillValidationError.futureDate(tenSecondsFromNowDate).errorDescription,
+                       "This is a date in the future: \(tenSecondsFromNowDate).")
     }
 }


### PR DESCRIPTION
# What 

Added enum `BillValidationError` with errors that can be caused by incorrect input data for the bill's fields.

# Why 

It's part of the work on issue #16. 

# How 

- Added enum `BillValidationError` with necessary error cases that listed in the [_Set of Errors_](https://github.com/ios-course/link-team-project/issues/16#:~:text=in%20the%20future.-,Set%20of%20Errors,-invalidParticipantName%20%2D%20indicates%20invalid) section.

- Added tests for `errorDescription` property of the `BillValidationError`. 
