### PR TITLE
Add `AddBillElementsView` to `AddBillView`.

### DIFF
--- a/JourneysSquad/JourneysSquad/View/AddBillView/AddBillView.swift
+++ b/JourneysSquad/JourneysSquad/View/AddBillView/AddBillView.swift
@@ -6,7 +6,7 @@ struct AddBillView: View {
     var body: some View {
         NavigationStack {
             VStack {
-                Text("")
+                AddBillElementsView()
             }
             .navigationTitle(titleText)
             .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
# What

Added  `AddBillElementsView` that contains fields to input to  `AddBillView`.

# Why

It closes #73.

# How

The `AddBillElementsView` is called from the `NavigationStack` in the `AddBillView`.